### PR TITLE
fix(descheduler): update resource thresholds in configuration

### DIFF
--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -126,12 +126,12 @@ data:
       - name: RemovePodsViolatingTopologySpreadConstraint
       - args:
           targetThresholds:
-            cpu: 80
-            memory: 80
+            cpu: 85
+            memory: 85
             pods: 100
           thresholds:
-            cpu: 50
-            memory: 50
+            cpu: 60
+            memory: 60
             pods: 50
         name: LowNodeUtilization
       plugins:
@@ -177,7 +177,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5041118ec1a37f7e943c044294f41d2d791a21698a50d33b2aedc4e47b035d96
+        checksum/config: 9a94a001cc9427698661fcf3ff29f3a6c9f67206db556025a1b48b7b15abcee8
       labels:
         app.kubernetes.io/instance: descheduler
         app.kubernetes.io/name: descheduler

--- a/descheduler/operator-values.yaml
+++ b/descheduler/operator-values.yaml
@@ -35,12 +35,12 @@ deschedulerPolicy:
         - name: LowNodeUtilization
           args:
             thresholds:
-              cpu: 50
-              memory: 50
+              cpu: 60
+              memory: 60
               pods: 50
             targetThresholds:
-              cpu: 80
-              memory: 80
+              cpu: 85
+              memory: 85
               pods: 100
       plugins:
         balance:


### PR DESCRIPTION
Adjust the CPU and memory thresholds for LowNodeUtilization 
plugin in descheduler configuration files. Increase target 
thresholds from 80 to 85 and set regular thresholds from 
50 to 60 to improve resource management. Update the 
checksum for configuration annotations to reflect these 
changes.