### PR TITLE
perf: right-size descheduler CPU request from 500m to 50m

### DIFF
--- a/descheduler.yaml
+++ b/descheduler.yaml
@@ -217,7 +217,7 @@ spec:
             cpu: 500m
             memory: 256Mi
           requests:
-            cpu: 500m
+            cpu: 50m
             memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/descheduler/operator-values.yaml
+++ b/descheduler/operator-values.yaml
@@ -1,5 +1,15 @@
 kind: Deployment
 
+# Chart default reserves 500m CPU; observed steady-state usage is ~1m.
+# Reserve a small request and keep a generous limit for periodic eviction sweeps.
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
 deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10


### PR DESCRIPTION
The descheduler chart default reserves **500m** CPU, but the controller's observed steady-state usage is **~1m**. This sets a 50m request via `operator-values.yaml` (keeping the 500m limit so periodic eviction sweeps can still burst) and regenerates `descheduler.yaml`.

**Motivation:** the 500m reservation was a contributor to `KubeCPUOvercommit` on a downstream cluster. After this is released, the consumer bumps the module `ref` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
